### PR TITLE
Correct TonApiClient get_nft_items get params

### DIFF
--- a/TonTools/Providers/TonApiClient.py
+++ b/TonTools/Providers/TonApiClient.py
@@ -59,7 +59,7 @@ class TonApiClient:
         async with aiohttp.ClientSession() as session:
             url = self.base_url + 'nft/getItems'
             params = {
-                'addresses': nft_addresses
+                'addresses': ','.join(nft_addresses)
             }
             response = await session.get(url=url, params=params, headers=self.headers)
             response = await process_response(response)


### PR DESCRIPTION
Неправильно формировался запрос в nft/getItems. 
Вот пример с tonapi.io `curl -X 'GET' \
  'https://tonapi.io/v1/nft/getItems?addresses=EQCiG_NLzKcSAyB6xh91kPXL7EdSP5TLGaiPdwDxtL717y3k,EQCTeECstzM3I6ZFKTeppfTf77Zd9dYYUejSVPx3R97ncBuh,EQDOGcdfQ-n3nRiiT10XzONYmDZPwIjqrDLOw2SPMM7SvqZj' \
  -H 'accept: application/json'`
