### PR TITLE
fix:Fix an odd error in get transactions,not decoding well if transacctions

### DIFF
--- a/TonTools/Contracts/Contract.py
+++ b/TonTools/Contracts/Contract.py
@@ -35,7 +35,7 @@ class Msg:
         self.source = data['source']
         self.destination = data['destination']
         self.value = data['value']
-        self.msg_data = base64.b64decode(data['msg_data']).decode().split('\x00')[-1] if not is_boc(data['msg_data']) else data['msg_data']
+        self.msg_data = base64.b64decode(data['msg_data']).decode().split('\x00')[-1] if isBase64(data['msg_data']) else data['msg_data']
         self.op_code = self.try_get_op() if 'op_code' not in data else data['op_code']
 
     def try_detect_type(self):


### PR DESCRIPTION
Fix an odd error in get transactions,not decoding well if transacctions are not in base64  mostly ocurring with v3r2 walllets
![image](https://github.com/yungwine/TonTools/assets/47145585/b6c445ef-34fa-4f5c-aaff-a1acd842609f)


